### PR TITLE
donut labs: apr 15 drip feed notes

### DIFF
--- a/src/donuts_labs_battery/evidence_drip_feed.md
+++ b/src/donuts_labs_battery/evidence_drip_feed.md
@@ -3,11 +3,9 @@
 ## April 15 2026
 
 - Slightly active cooling (fans) in the Verge.
-- Finally stated explicitly that the charging speed is limited in the bike due to
-  not having a liquid cooled design. Also claiming < 5 min in a typical car with
-  liquid cooling design. (No new evidence.)
-- Claims "very little degradation" across motorcycle life span even every
-  charge at 5C.
+- Finally stated explicitly that the charging speed is limited in the bike due to not having a liquid cooled design.
+  Also claiming < 5 min in a typical car with liquid cooling design. (No new evidence.)
+- Claims "very little degradation" across motorcycle life span even every charge at 5C.
 
 ## April 1 2026 - Interview (AKA "we love trolling you all")
 

--- a/src/donuts_labs_battery/evidence_drip_feed.md
+++ b/src/donuts_labs_battery/evidence_drip_feed.md
@@ -1,5 +1,14 @@
 # Evidence drip feed
 
+## April 15 2026
+
+* Slightly active cooling (fans) in the Verge.
+* Finally stated explicitly that the charging speed is limited in the bike due to
+  not having a liquid cooled design. Also claiming < 5 min in a typical car with
+  liquid cooling design. (No new evidence.)
+* Claims "very little degradation" across motorcycle life span even every
+  charge at 5C.
+
 ## April 1 2026 - Interview (AKA "we love trolling you all")
 
 Well at least he acknowleged they've been "teasing" :P

--- a/src/donuts_labs_battery/evidence_drip_feed.md
+++ b/src/donuts_labs_battery/evidence_drip_feed.md
@@ -2,11 +2,11 @@
 
 ## April 15 2026
 
-* Slightly active cooling (fans) in the Verge.
-* Finally stated explicitly that the charging speed is limited in the bike due to
+- Slightly active cooling (fans) in the Verge.
+- Finally stated explicitly that the charging speed is limited in the bike due to
   not having a liquid cooled design. Also claiming < 5 min in a typical car with
   liquid cooling design. (No new evidence.)
-* Claims "very little degradation" across motorcycle life span even every
+- Claims "very little degradation" across motorcycle life span even every
   charge at 5C.
 
 ## April 1 2026 - Interview (AKA "we love trolling you all")


### PR DESCRIPTION
Keep the Donut Labs evidence log current with the April 15 Verge interview so the latest battery and thermal-management claims are captured in the same running record as the earlier drip-feed notes.