### PR TITLE
donut labs: add apr 29 drip feed note

### DIFF
--- a/src/donuts_labs_battery/evidence_drip_feed.md
+++ b/src/donuts_labs_battery/evidence_drip_feed.md
@@ -1,5 +1,9 @@
 # Evidence drip feed
 
+## April 29 2026 - Swappable Solid-State Battery Demonstration
+
+Did nothing to reveal evidence/data about actual battery claims. No real news.
+
 ## April 15 2026
 
 - Slightly active cooling (fans) in the Verge.


### PR DESCRIPTION
Document the April 29 swappable battery demonstration in the Donut Lab evidence drip feed.

The demonstration does not appear to add new evidence for the actual battery performance claims, so the note is intentionally short.
