### PR TITLE
donut labs: add manufacturing drip feed note

### DIFF
--- a/src/donuts_labs_battery/evidence_drip_feed.md
+++ b/src/donuts_labs_battery/evidence_drip_feed.md
@@ -1,5 +1,14 @@
 # Evidence drip feed
 
+## Jun 3 2026 - Manufacturing and scaling
+
+Video: [Manufacturing & Scaling | I Donut Believe](https://www.youtube.com/watch?v=BjsqMlikxac)
+
+Initially written: Jun 3 2026
+
+- Some of the additional detail is interesting, but it is still just claims. In evidence terms, this was a nothing
+  burger.
+
 ## May 13 2026 - Swelling test
 
 VTT report: [VTT_CustomerReport_Swelling_test.pdf](20260513_swelling_test/VTT_CustomerReport_Swelling_test.pdf)


### PR DESCRIPTION
The June 3 manufacturing video belongs in the same evidence drip-feed timeline as the VTT reports and pack demos.

The useful takeaway is mostly negative: the video adds some detail about what Donut wants viewers to believe about scaling, but it still does not provide externally checkable evidence about finished-cell production or the claimed 1 GWh ramp.
