### PR TITLE
donut labs: add Ziroth critique note

### DIFF
--- a/src/donuts_labs_battery/evidence_drip_feed.md
+++ b/src/donuts_labs_battery/evidence_drip_feed.md
@@ -1,5 +1,18 @@
 # Evidence drip feed
 
+## Jun 8 2026 - Ziroth critique
+
+Video: [Exposing The Solid State Donut Battery. It's Over.](https://www.youtube.com/watch?v=j5oyVNjrUPI)
+
+Initially written: Jun 8 2026
+
+This is not a Donut Lab release entry.
+
+I consider this video highly recommended for anyone following this story, so I wanted to include it here.
+
+I am not treating a YouTube critique as proof by itself. This significantly decreases my priors that the Donut Lab
+claims are legit.
+
 ## Jun 3 2026 - Manufacturing and scaling
 
 Video: [Manufacturing & Scaling | I Donut Believe](https://www.youtube.com/watch?v=BjsqMlikxac)


### PR DESCRIPTION
This video is not part of the Donut Lab release cadence, but it is relevant enough to include in the drip feed for anyone following the story.

The note keeps the caveat explicit: a YouTube critique is not proof by itself, but it does move my priors downward on the legitimacy of the Donut Lab claims.
