### PR TITLE
ci: require master PR base

### DIFF
--- a/.github/workflows/pr-base.yml
+++ b/.github/workflows/pr-base.yml
@@ -1,0 +1,17 @@
+name: PR Base
+
+on:
+  pull_request:
+
+jobs:
+  require-master-base:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require master as PR base
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          if [ "$BASE_REF" != "master" ]; then
+            echo "PR base must be master, got '$BASE_REF'." >&2
+            exit 1
+          fi


### PR DESCRIPTION
This repo uses stacked PRs. GitHub tracks PR ancestry by branch name, so a child PR can otherwise be merged into its parent branch through the web UI. The guard targets `master` because `origin/HEAD` points there.

After this lands, make `require-master-base` a required check in branch protection or repository rulesets. Until GitHub requires it, the workflow is advisory.
