### PR TITLE
chore: refresh dprint plugins

### DIFF
--- a/dprint.json
+++ b/dprint.json
@@ -8,7 +8,7 @@
   "toml": {},
   "excludes": ["**/*-lock.json", "book/"],
   "plugins": [
-    "https://plugins.dprint.dev/json-0.21.3.wasm",
+    "https://plugins.dprint.dev/json-0.22.0.wasm",
     "https://plugins.dprint.dev/markdown-0.22.1.wasm",
     "https://plugins.dprint.dev/toml-0.7.0.wasm"
   ]


### PR DESCRIPTION
This is the mechanical result of running the dprint config refresh commands from the modernization checklist. The only plugin that changed was the JSON formatter.
